### PR TITLE
Add bazel to docker image.

### DIFF
--- a/build_tools/install_bazel.sh
+++ b/build_tools/install_bazel.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+echo $BAZEL_VERSION
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" == "aarch64" ]]; then
+  ARCH="arm64"
+fi
+
+# We could do the whole apt install dance, but this technique works across a
+# range of platforms.
+curl --silent --fail --show-error --location \
+  "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION?}/bazel-${BAZEL_VERSION?}-linux-${ARCH}" \
+  --output /usr/bin/bazel
+chmod +x /usr/bin/bazel
+
+if [[ "$(bazel --version)" != "bazel ${BAZEL_VERSION}" ]]; then
+  echo "Bazel installation failed" >&2
+  exit 1
+fi

--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -6,6 +6,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:8ab319e0ecea2f642b2436dbf736993f1
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \
     yum install -y capstone-devel tbb-devel libzstd-devel && \
+    yum install -y java-11-openjdk-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -19,6 +20,12 @@ RUN  echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/${ROCM
   && echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${AMDGPU_VERSION}/rhel/${RHEL_VERSION}/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo \
   && yum install -y rocm-dev \
   && yum clean all
+
+######## Bazel ########
+ARG BAZEL_VERSION=5.1.0
+WORKDIR /install-bazel
+COPY build_tools/install_bazel.sh ./
+RUN ./install_bazel.sh && rm -rf /install-bazel
 
 ######## GIT CONFIGURATION ########
 # Git started enforcing strict user checking, which thwarts version


### PR DESCRIPTION
Based on the docker file removed from IREE repo but without ROCm installed as meant to be used purely for bazel building, so kept it smaller.