### PR TITLE
Install rust and cargo in manylinux image, prune unused packages.

### DIFF
--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -1,7 +1,7 @@
 # We build our portable linux releases on the manylinux (RHEL-based)
 # images, with custom additional packages installed. We switch to
 # new upstream versions as needed.
-FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:9042a22d33af2223ff7a3599f236aff1e4ffd07e1ed1ac93a58877638317515f
+FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:078fda423323b8483cb8320ac6a0b7c3933d6c332e53225d077ff3186b3ce07e
 
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \

--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -6,6 +6,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:078fda423323b8483cb8320ac6a0b7c39
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \
     yum install -y capstone-devel tbb-devel libzstd-devel && \
+    yum install -y rust cargo && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -6,26 +6,8 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:078fda423323b8483cb8320ac6a0b7c39
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \
     yum install -y capstone-devel tbb-devel libzstd-devel && \
-    yum install -y java-11-openjdk-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
-
-######## AMD ROCM #######
-ARG ROCM_VERSION=5.2.1
-ARG AMDGPU_VERSION=22.20.1
-ARG RHEL_VERSION=8.6
-
-# Install the ROCm rpms
-RUN  echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/${ROCM_VERSION}/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo \
-  && echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${AMDGPU_VERSION}/rhel/${RHEL_VERSION}/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo \
-  && yum install -y rocm-dev \
-  && yum clean all
-
-######## Bazel ########
-ARG BAZEL_VERSION=5.1.0
-WORKDIR /install-bazel
-COPY build_tools/install_bazel.sh ./
-RUN ./install_bazel.sh && rm -rf /install-bazel
 
 ######## GIT CONFIGURATION ########
 # Git started enforcing strict user checking, which thwarts version


### PR DESCRIPTION
Progress on https://github.com/nod-ai/shark-ai/issues/679

Tested:
```bash
cd base-docker-images
sudo docker buildx build --file dockerfiles/manylinux_x86_64.Dockerfile . --tag manylinux:latest

cd ../shark-ai
CACHE_DIR=~/.shark-ai-cache \
  OUTPUT_DIR=/tmp/wheelhouse \
  MANYLINUX_DOCKER_IMAGE=manylinux:latest \
  sudo -E ./shortfin/build_tools/build_linux_package.sh

# ******************** BUILD COMPLETE ********************
# + echo 'Generated binaries:'
# Generated binaries:
# + ls -l /tmp/wheelhouse
# total 40084
# -rw-r--r-- 1 root root 13691622 Dec 11 15:48 shortfin-3.0.0rc20241118-cp311-cp311-manylinux_2_28_x86_64.whl
# -rw-r--r-- 1 root root 13682296 Dec 11 15:50 shortfin-3.0.0rc20241118-cp312-cp312-manylinux_2_28_x86_64.whl
# -rw-r--r-- 1 root root 13666409 Dec 11 15:52 shortfin-3.0.0rc20241118-cp313-cp313-manylinux_2_28_x86_64.whl

```

Note that this image is in use without pinning in some repositories, but from what I can tell, all affected workflows are already failing and the code is unmaintained. For example: https://github.com/nod-ai/SRT/blob/373685f1cfff5dd6d934bf5858b6d58fc7a5bcdf/build_tools/pkgci/build_linux_packages.sh#L67.